### PR TITLE
feat: Add Activity Management CRUD endpoints

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -8,8 +8,23 @@ for extracurricular activities at Mergington High School.
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+from typing import Optional
 import os
 from pathlib import Path
+
+# Pydantic models for request/response validation
+class ActivityCreate(BaseModel):
+    """Model for creating a new activity"""
+    description: str
+    schedule: str
+    max_participants: int
+
+class ActivityUpdate(BaseModel):
+    """Model for updating an activity"""
+    description: Optional[str] = None
+    schedule: Optional[str] = None
+    max_participants: Optional[int] = None
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -130,3 +145,89 @@ def unregister_from_activity(activity_name: str, email: str):
     # Remove student
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}
+
+
+# CRUD Operations for Activities
+
+@app.post("/activities")
+def create_activity(name: str, activity_data: ActivityCreate):
+    """Create a new activity"""
+    # Validate activity doesn't already exist
+    if name in activities:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Activity '{name}' already exists"
+        )
+    
+    # Validate max_participants is positive
+    if activity_data.max_participants <= 0:
+        raise HTTPException(
+            status_code=400,
+            detail="max_participants must be a positive number"
+        )
+    
+    # Create the new activity
+    activities[name] = {
+        "description": activity_data.description,
+        "schedule": activity_data.schedule,
+        "max_participants": activity_data.max_participants,
+        "participants": []
+    }
+    
+    return {
+        "message": f"Activity '{name}' created successfully",
+        "activity": {name: activities[name]}
+    }
+
+
+@app.get("/activities/{activity_name}")
+def get_activity(activity_name: str):
+    """Get details of a specific activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    
+    return {activity_name: activities[activity_name]}
+
+
+@app.put("/activities/{activity_name}")
+def update_activity(activity_name: str, activity_data: ActivityUpdate):
+    """Update an existing activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    
+    # Get the activity
+    activity = activities[activity_name]
+    
+    # Update fields if provided
+    if activity_data.description is not None:
+        activity["description"] = activity_data.description
+    
+    if activity_data.schedule is not None:
+        activity["schedule"] = activity_data.schedule
+    
+    if activity_data.max_participants is not None:
+        if activity_data.max_participants <= 0:
+            raise HTTPException(
+                status_code=400,
+                detail="max_participants must be a positive number"
+            )
+        activity["max_participants"] = activity_data.max_participants
+    
+    return {
+        "message": f"Activity '{activity_name}' updated successfully",
+        "activity": {activity_name: activity}
+    }
+
+
+@app.delete("/activities/{activity_name}")
+def delete_activity(activity_name: str):
+    """Delete an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    
+    # Delete the activity
+    del activities[activity_name]
+    
+    return {"message": f"Activity '{activity_name}' deleted successfully"}


### PR DESCRIPTION
## Description
Implements full Activity Management CRUD functionality to allow admins to create, read, update, and delete activities (#8).

## Changes
- **POST /activities** - Create new activities with description, schedule, and max participants
- **GET /activities/{activity_name}** - Retrieve details of a specific activity
- **PUT /activities/{activity_name}** - Update activity information (partial updates supported)
- **DELETE /activities/{activity_name}** - Remove activities from the system

## Technical Details
- Added Pydantic models (`ActivityCreate`, `ActivityUpdate`) for request validation
- All endpoints include comprehensive error handling
- Validates data (e.g., positive participant counts, no duplicate activity names)
- Maintains backward compatibility with existing signup/unregister functionality
- Preserves participant lists when updating activities

## Testing Notes
The endpoints can be tested using the FastAPI interactive documentation at `/docs` once deployed.